### PR TITLE
feat: support vscode html features using htmlLanguageParticipants

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
   "devDependencies": {
     "prettier": "2.7.1"
   },
-  "activationEvents": [
-    "onLanguage:mako"
-  ],
   "contributes": {
     "languages": [
       {
@@ -76,6 +73,12 @@
     "breakpoints": [
       {
         "language": "mako"
+      }
+    ],
+    "htmlLanguageParticipants": [
+      {
+        "languageId": "mako",
+        "autoInsert": true
       }
     ]
   }

--- a/snippets/mako-snippets.json
+++ b/snippets/mako-snippets.json
@@ -37,6 +37,11 @@
   "If condition": {
     "prefix": "if",
     "description": "IF condition",
+    "body": ["% if $1:", "% endif"]
+  },
+  "If-Else condition": {
+    "prefix": "ifelse",
+    "description": "IF-Else condition",
     "body": ["% if $1:", "$2", "% else:", "% endif"]
   },
   "Include": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -3,18 +3,16 @@ const vscode = require('vscode')
 // This hack is necessary to ensure that the vscode.html-language-features extension is activated in order to enable
 // htmlLanguageParticipants support. Please see https://github.com/microsoft/vscode/issues/160585 for more info.
 async function activate() {
+  const output = vscode.window.createOutputChannel('Mako')
   const htmlExtension = vscode.extensions.getExtension('vscode.html-language-features')
-
   if (!htmlExtension) {
-    const output = vscode.window.createOutputChannel('Mako')
-
     output.appendLine(
       'Warning: Could not find vscode.html-language-features. HTML Language Participants support will be disabled.',
     )
     return
   }
-
   await htmlExtension?.activate()
+  output.appendLine('HTML Language Participants support enabled.')
 }
 
 module.exports = {


### PR DESCRIPTION
Support `htmlLanguageParticipants` config which auto using vscode html features:
https://code.visualstudio.com/docs/languages/html