### PR TITLE
Add support for other language templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,21 @@
           "dark": "./icon.png"
         },
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "mako-python",
+        "aliases": [
+          "Mako template (Python)"
+        ],
+        "extensions": [
+          ".py.mako",
+          ".pyi.mako"
+        ],
+        "icon": {
+          "light": "./icon.png",
+          "dark": "./icon.png"
+        },
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -82,7 +97,15 @@
       {
         "language": "mako-html",
         "scopeName": "source.mako.templates.html",
-        "path": "./syntaxes/mako-html.tmLanguage.json"
+        "path": "./syntaxes/mako-html.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.mako": "text.html.basic"
+        }
+      },
+      {
+        "language": "mako-python",
+        "scopeName": "source.mako.templates.python",
+        "path": "./syntaxes/mako-python.tmLanguage.json"
       }
     ],
     "snippets": [
@@ -94,6 +117,11 @@
       {
         "language": "mako-html",
         "scopeName": "source.mako.templates.html",
+        "path": "./snippets/mako-snippets.json"
+      },
+      {
+        "language": "mako-python",
+        "scopeName": "source.mako.templates.python",
         "path": "./snippets/mako-snippets.json"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,20 @@
           "dark": "./icon.png"
         },
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "mako-html",
+        "aliases": [
+          "Mako template (HTML)"
+        ],
+        "extensions": [
+          ".html.mako"
+        ],
+        "icon": {
+          "light": "./icon.png",
+          "dark": "./icon.png"
+        },
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -64,12 +78,22 @@
         "language": "mako",
         "scopeName": "source.mako",
         "path": "./syntaxes/mako.tmLanguage.json"
+      },
+      {
+        "language": "mako-html",
+        "scopeName": "source.mako.templates.html",
+        "path": "./syntaxes/mako-html.tmLanguage.json"
       }
     ],
     "snippets": [
       {
         "language": "mako",
         "scopeName": "source.mako",
+        "path": "./snippets/mako-snippets.json"
+      },
+      {
+        "language": "mako-html",
+        "scopeName": "source.mako.templates.html",
         "path": "./snippets/mako-snippets.json"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       {
         "id": "mako",
         "aliases": [
-          "HTML (Mako)",
+          "Mako template",
           "mako"
         ],
         "extensions": [
@@ -62,14 +62,14 @@
     "grammars": [
       {
         "language": "mako",
-        "scopeName": "text.html.mako",
+        "scopeName": "source.mako",
         "path": "./syntaxes/mako.tmLanguage.json"
       }
     ],
     "snippets": [
       {
         "language": "mako",
-        "scopeName": "text.html.mako",
+        "scopeName": "source.mako",
         "path": "./snippets/mako-snippets.json"
       }
     ],

--- a/syntaxes/mako-html.tmLanguage.json
+++ b/syntaxes/mako-html.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tmlanguage.json",
+  "name": "Mako template (HTML)",
+  "scopeName": "source.mako.templates.html",
+  "patterns": [
+    {
+      "include": "source.mako"
+    },
+    {
+      "include": "text.html.basic"
+    }
+  ]
+}

--- a/syntaxes/mako-python.tmLanguage.json
+++ b/syntaxes/mako-python.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tmlanguage.json",
+  "name": "Mako template (Python)",
+  "scopeName": "source.mako.templates.python",
+  "patterns": [
+    {
+      "include": "source.mako"
+    },
+    {
+      "include": "source.python"
+    }
+  ]
+}

--- a/syntaxes/mako.tmLanguage.json
+++ b/syntaxes/mako.tmLanguage.json
@@ -1,7 +1,7 @@
 {
-  "fileTypes": ["mako", "html"],
-  "name": "Mako",
-  "scopeName": "text.html.mako",
+  "fileTypes": [ "mako" ],
+  "name": "Mako template",
+  "scopeName": "source.mako",
   "foldingStartMarker": "(<(?i:(head|table|div|style|script|ul|ol|form|dl))\\b.*?>|\\{)",
   "foldingStopMarker": "(</(?i:(head|table|div|style|script|ul|ol|form|dl))>|\\})",
   "patterns": [
@@ -51,8 +51,7 @@
         }
       },
       "end": "(</%(\\2)>)",
-      "name": "source.mako.text",
-      "patterns": []
+      "name": "source.mako.text"
     },
     {
       "begin": "(<%(doc)>)",
@@ -65,8 +64,7 @@
         }
       },
       "end": "(</%(\\2)>)",
-      "name": "comment.block.mako",
-      "patterns": []
+      "name": "comment.block.mako"
     },
     {
       "begin": "(\\${)",
@@ -370,9 +368,6 @@
           "include": "#tag-stuff"
         }
       ]
-    },
-    {
-      "include": "text.html.basic"
     }
   ],
   "repository": {
@@ -732,7 +727,7 @@
         }
       ]
     },
-    "embedded-code": {}
+    "embedded-code": { }
   },
   "uuid": "8580C15A-0134-4D25-9705-14F98729B2C5"
 }


### PR DESCRIPTION
Adds support for Mako syntax highlighting in language templates other than HTML. This is achieved by adding more language definitions, each associated with a different template, e.g. `mako-html` for `.html.mako` files or `mako-python` for `.py.mako` files (like [this one](https://github.com/gnuradio/gnuradio/blob/5547874b88f32960f659466cc5be7111368768d5/grc/core/generator/flow_graph.py.mako)).

Another way would be language embedding, but that one doesn't recognize file extensions and instead requires additional syntax (e.g. comments like `## language=my-language`).

Resolves #3.

* [ ] Remove HTML-specific stuff from Mako grammar
* [ ] Add language definitions for requested languages
  * [x] HTML
  * [x] Python
  * [ ] conf
  * [ ] ini
* [ ] Create a build script / template to automate adding new languages?